### PR TITLE
feat: context manager for FileReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.4.0
+
+- Added context manager to FileReader
+
 ## v0.3.2
 
 - Do aligned reads for find next chr and to ascii lower/upper

--- a/ExtraMojo/fs/file.mojo
+++ b/ExtraMojo/fs/file.mojo
@@ -125,7 +125,22 @@ struct FileReader:
         _ = self._fill_buffer()
 
     fn __del__(owned self):
+        try:
+            self.fh.close()
+        except:
+            pass
         self.buffer.free()
+
+    fn __enter__(owned self) -> Self:
+        return self^
+
+    fn __moveinit__(out self, owned existing: Self):
+        self.fh = existing.fh^
+        self.file_offset = existing.file_offset
+        self.buffer_offset = existing.buffer_offset
+        self.buffer = existing.buffer
+        self.buffer_size = existing.buffer_size
+        self.buffer_len = existing.buffer_len
 
     fn read_until(
         mut self, mut line_buffer: List[UInt8], char: UInt = NEW_LINE

--- a/README.md
+++ b/README.md
@@ -29,14 +29,13 @@ Reading a file line by line.
 from ExtraMojo.fs.file import FileReader, read_lines, for_each_line
 from ExtraMojo.tensor import slice_tensor
 
-fn test_read_until(file: Path, expected_lines: List[String]) raises:
-    var fh = open(file, "r")
-    var reader = FileReader(fh^, buffer_size=1024)
+fn test_context_manager_simple(file: Path, expected_lines: List[String]) raises:
     var buffer = List[UInt8]()
     var counter = 0
-    while reader.read_until(buffer) != 0:
-        assert_equal(expected_lines[counter].as_bytes(), buffer)
-        counter += 1
+    with FileReader(open(file, "r"), buffer_size=200) as reader:
+        while reader.read_until(buffer) != 0:
+            assert_equal(List(expected_lines[counter].as_bytes()), buffer)
+            counter += 1
     assert_equal(counter, len(expected_lines))
     print("Successful read_until")
 

--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -4,7 +4,7 @@ channels = ["conda-forge", "https://conda.modular.com/max"]
 description = "Useful things that aren't in the standard library."
 name = "ExtraMojo"
 platforms = ["osx-arm64", "linux-64"]
-version = "0.3.2"
+version = "0.3.3"
 license = "Unlicense OR MIT"
 
 [tasks]

--- a/test_file.mojo
+++ b/test_file.mojo
@@ -40,6 +40,17 @@ fn test_read_until(file: Path, expected_lines: List[String]) raises:
     print("Successful read_until")
 
 
+fn test_context_manager_simple(file: Path, expected_lines: List[String]) raises:
+    var buffer = List[UInt8]()
+    var counter = 0
+    with FileReader(open(file, "r"), buffer_size=200) as reader:
+        while reader.read_until(buffer) != 0:
+            assert_equal(List(expected_lines[counter].as_bytes()), buffer)
+            counter += 1
+    assert_equal(counter, len(expected_lines))
+    print("Successful read_until")
+
+
 fn test_read_lines(file: Path, expected_lines: List[String]) raises:
     var lines = read_lines(str(file))
     assert_equal(len(lines), len(expected_lines))


### PR DESCRIPTION
```python
fn test_context_manager_simple(file: Path, expected_lines: List[String]) raises:
    var buffer = List[UInt8]()
    var counter = 0
    with FileReader(open(file, "r"), buffer_size=200) as reader:
        while reader.read_until(buffer) != 0:
            assert_equal(List(expected_lines[counter].as_bytes()), buffer)
            counter += 1
    assert_equal(counter, len(expected_lines))
    print("Successful read_until")
```