### PR TITLE
Pretty docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
           path: docs/site/public
 
       - name: Deploy to GitHub Pages
-          # if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: crazy-max/ghaction-github-pages@v4
         with:
           target_branch: gh-pages

--- a/ExtraMojo/cli/parser.mojo
+++ b/ExtraMojo/cli/parser.mojo
@@ -1,6 +1,6 @@
 """A very basic CLI Opt Parser.
 
-```mojo
+```mojo {doctest="parser" class="no-wrap"}
 from testing import assert_equal, assert_true
 from ExtraMojo.cli.parser import OptParser, OptConfig, OptKind
 

--- a/docs/site/assets/css/custom.css
+++ b/docs/site/assets/css/custom.css
@@ -1,0 +1,897 @@
+/* navigation bar */
+.hextra-scrollbar a {
+  overflow: hidden;
+  word-break: keep-all;
+}
+
+/* code blocks */
+.hextra-code-block pre {
+  font-size: 1.0em;
+}
+
+/* code in headings */
+.content :where(h1, h2, h3, h4):not(:where([class~="not-prose"], [class~="not-prose"] *)) code {
+  font-size: 100%;
+}
+
+/* smaller headings */
+.content :where(h1):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  font-size: 2.0rem;
+}
+
+.content :where(h2):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  font-size: 1.66rem;
+  margin-top: 2.0rem;
+}
+
+.content :where(h3):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  font-size: 1.4rem;
+  margin-top: 1.66rem;
+}
+
+/* syntax highlighting with GitHub style */
+
+/* Generated using: hugo gen chromastyles --style=github */
+/* Background */
+html:not(.dark) .bg {
+  background-color: #fff;
+}
+
+/* PreWrapper */
+html:not(.dark) .chroma {
+  background-color: hsl(var(--primary-hue) var(--primary-saturation) calc(calc(var(--primary-lightness) / 50) * 39) / 0.05);
+}
+
+/* Other */
+html:not(.dark) .chroma .x {}
+
+/* Error */
+html:not(.dark) .chroma .err {
+  color: #f6f8fa;
+  background-color: #82071e
+}
+
+/* CodeLine */
+html:not(.dark) .chroma .cl {}
+
+/* LineLink */
+html:not(.dark) .chroma .lnlinks {
+  outline: none;
+  text-decoration: none;
+  color: inherit
+}
+
+/* LineTableTD */
+html:not(.dark) .chroma .lntd {
+  vertical-align: top;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+/* LineTable */
+html:not(.dark) .chroma .lntable {
+  border-spacing: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+/* LineHighlight */
+html:not(.dark) .chroma .hl {
+  background-color: #e5e5e5
+}
+
+/* LineNumbersTable */
+html:not(.dark) .chroma .lnt {
+  white-space: pre;
+  -webkit-user-select: none;
+  user-select: none;
+  margin-right: 0.4em;
+  padding: 0 0.4em 0 0.4em;
+  color: #7f7f7f
+}
+
+/* LineNumbers */
+html:not(.dark) .chroma .ln {
+  white-space: pre;
+  -webkit-user-select: none;
+  user-select: none;
+  margin-right: 0.4em;
+  padding: 0 0.4em 0 0.4em;
+  color: #7f7f7f
+}
+
+/* Line */
+html:not(.dark) .chroma .line {
+  display: flex;
+}
+
+/* Keyword */
+html:not(.dark) .chroma .k {
+  color: #cf222e
+}
+
+/* KeywordConstant */
+html:not(.dark) .chroma .kc {
+  color: #cf222e
+}
+
+/* KeywordDeclaration */
+html:not(.dark) .chroma .kd {
+  color: #cf222e
+}
+
+/* KeywordNamespace */
+html:not(.dark) .chroma .kn {
+  color: #cf222e
+}
+
+/* KeywordPseudo */
+html:not(.dark) .chroma .kp {
+  color: #cf222e
+}
+
+/* KeywordReserved */
+html:not(.dark) .chroma .kr {
+  color: #cf222e
+}
+
+/* KeywordType */
+html:not(.dark) .chroma .kt {
+  color: #cf222e
+}
+
+/* Name */
+html:not(.dark) .chroma .n {}
+
+/* NameAttribute */
+html:not(.dark) .chroma .na {
+  color: #1f2328
+}
+
+/* NameBuiltin */
+html:not(.dark) .chroma .nb {
+  color: #6639ba
+}
+
+/* NameBuiltinPseudo */
+html:not(.dark) .chroma .bp {
+  color: #6a737d
+}
+
+/* NameClass */
+html:not(.dark) .chroma .nc {
+  color: #1f2328
+}
+
+/* NameConstant */
+html:not(.dark) .chroma .no {
+  color: #0550ae
+}
+
+/* NameDecorator */
+html:not(.dark) .chroma .nd {
+  color: #0550ae
+}
+
+/* NameEntity */
+html:not(.dark) .chroma .ni {
+  color: #6639ba
+}
+
+/* NameException */
+html:not(.dark) .chroma .ne {}
+
+/* NameFunction */
+html:not(.dark) .chroma .nf {
+  color: #6639ba
+}
+
+/* NameFunctionMagic */
+html:not(.dark) .chroma .fm {}
+
+/* NameLabel */
+html:not(.dark) .chroma .nl {
+  color: #900;
+  font-weight: bold
+}
+
+/* NameNamespace */
+html:not(.dark) .chroma .nn {
+  color: #24292e
+}
+
+/* NameOther */
+html:not(.dark) .chroma .nx {
+  color: #1f2328
+}
+
+/* NameProperty */
+html:not(.dark) .chroma .py {}
+
+/* NameTag */
+html:not(.dark) .chroma .nt {
+  color: #0550ae
+}
+
+/* NameVariable */
+html:not(.dark) .chroma .nv {
+  color: #953800
+}
+
+/* NameVariableClass */
+html:not(.dark) .chroma .vc {
+  color: #953800
+}
+
+/* NameVariableGlobal */
+html:not(.dark) .chroma .vg {
+  color: #953800
+}
+
+/* NameVariableInstance */
+html:not(.dark) .chroma .vi {
+  color: #953800
+}
+
+/* NameVariableMagic */
+html:not(.dark) .chroma .vm {}
+
+/* Literal */
+html:not(.dark) .chroma .l {}
+
+/* LiteralDate */
+html:not(.dark) .chroma .ld {}
+
+/* LiteralString */
+html:not(.dark) .chroma .s {
+  color: #0a3069
+}
+
+/* LiteralStringAffix */
+html:not(.dark) .chroma .sa {
+  color: #0a3069
+}
+
+/* LiteralStringBacktick */
+html:not(.dark) .chroma .sb {
+  color: #0a3069
+}
+
+/* LiteralStringChar */
+html:not(.dark) .chroma .sc {
+  color: #0a3069
+}
+
+/* LiteralStringDelimiter */
+html:not(.dark) .chroma .dl {
+  color: #0a3069
+}
+
+/* LiteralStringDoc */
+html:not(.dark) .chroma .sd {
+  color: #0a3069
+}
+
+/* LiteralStringDouble */
+html:not(.dark) .chroma .s2 {
+  color: #0a3069
+}
+
+/* LiteralStringEscape */
+html:not(.dark) .chroma .se {
+  color: #0a3069
+}
+
+/* LiteralStringHeredoc */
+html:not(.dark) .chroma .sh {
+  color: #0a3069
+}
+
+/* LiteralStringInterpol */
+html:not(.dark) .chroma .si {
+  color: #0a3069
+}
+
+/* LiteralStringOther */
+html:not(.dark) .chroma .sx {
+  color: #0a3069
+}
+
+/* LiteralStringRegex */
+html:not(.dark) .chroma .sr {
+  color: #0a3069
+}
+
+/* LiteralStringSingle */
+html:not(.dark) .chroma .s1 {
+  color: #0a3069
+}
+
+/* LiteralStringSymbol */
+html:not(.dark) .chroma .ss {
+  color: #032f62
+}
+
+/* LiteralNumber */
+html:not(.dark) .chroma .m {
+  color: #0550ae
+}
+
+/* LiteralNumberBin */
+html:not(.dark) .chroma .mb {
+  color: #0550ae
+}
+
+/* LiteralNumberFloat */
+html:not(.dark) .chroma .mf {
+  color: #0550ae
+}
+
+/* LiteralNumberHex */
+html:not(.dark) .chroma .mh {
+  color: #0550ae
+}
+
+/* LiteralNumberInteger */
+html:not(.dark) .chroma .mi {
+  color: #0550ae
+}
+
+/* LiteralNumberIntegerLong */
+html:not(.dark) .chroma .il {
+  color: #0550ae
+}
+
+/* LiteralNumberOct */
+html:not(.dark) .chroma .mo {
+  color: #0550ae
+}
+
+/* Operator */
+html:not(.dark) .chroma .o {
+  color: #0550ae
+}
+
+/* OperatorWord */
+html:not(.dark) .chroma .ow {
+  color: #0550ae
+}
+
+/* Punctuation */
+html:not(.dark) .chroma .p {
+  color: #1f2328
+}
+
+/* Comment */
+html:not(.dark) .chroma .c {
+  color: #57606a
+}
+
+/* CommentHashbang */
+html:not(.dark) .chroma .ch {
+  color: #57606a
+}
+
+/* CommentMultiline */
+html:not(.dark) .chroma .cm {
+  color: #57606a
+}
+
+/* CommentSingle */
+html:not(.dark) .chroma .c1 {
+  color: #57606a
+}
+
+/* CommentSpecial */
+html:not(.dark) .chroma .cs {
+  color: #57606a
+}
+
+/* CommentPreproc */
+html:not(.dark) .chroma .cp {
+  color: #57606a
+}
+
+/* CommentPreprocFile */
+html:not(.dark) .chroma .cpf {
+  color: #57606a
+}
+
+/* Generic */
+html:not(.dark) .chroma .g {}
+
+/* GenericDeleted */
+html:not(.dark) .chroma .gd {
+  color: #82071e;
+  background-color: #ffebe9
+}
+
+/* GenericEmph */
+html:not(.dark) .chroma .ge {
+  color: #1f2328
+}
+
+/* GenericError */
+html:not(.dark) .chroma .gr {}
+
+/* GenericHeading */
+html:not(.dark) .chroma .gh {}
+
+/* GenericInserted */
+html:not(.dark) .chroma .gi {
+  color: #116329;
+  background-color: #dafbe1
+}
+
+/* GenericOutput */
+html:not(.dark) .chroma .go {
+  color: #1f2328
+}
+
+/* GenericPrompt */
+html:not(.dark) .chroma .gp {}
+
+/* GenericStrong */
+html:not(.dark) .chroma .gs {}
+
+/* GenericSubheading */
+html:not(.dark) .chroma .gu {}
+
+/* GenericTraceback */
+html:not(.dark) .chroma .gt {}
+
+/* GenericUnderline */
+html:not(.dark) .chroma .gl {
+  text-decoration: underline
+}
+
+/* TextWhitespace */
+html:not(.dark) .chroma .w {
+  color: #fff
+}
+
+/* Generated using: hugo gen chromastyles --style=github-dark */
+/* Background */
+html.dark .bg {
+  color: #e6edf3;
+  background-color: #0d1117;
+}
+
+/* PreWrapper */
+html.dark .chroma {
+  color: #e6edf3;
+  background-color: hsl(var(--primary-hue) var(--primary-saturation) calc(var(--primary-lightness) + calc(calc(100% - var(--primary-lightness)) / 50) * 27) / 0.1);
+}
+
+/* Other */
+html.dark .chroma .x {}
+
+/* Error */
+html.dark .chroma .err {
+  color: #f85149
+}
+
+/* CodeLine */
+html.dark .chroma .cl {}
+
+/* LineLink */
+html.dark .chroma .lnlinks {
+  outline: none;
+  text-decoration: none;
+  color: inherit
+}
+
+/* LineTableTD */
+html.dark .chroma .lntd {
+  vertical-align: top;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+/* LineTable */
+html.dark .chroma .lntable {
+  border-spacing: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+/* LineHighlight */
+html.dark .chroma .hl {
+  background-color: #6e7681
+}
+
+/* LineNumbersTable */
+html.dark .chroma .lnt {
+  white-space: pre;
+  -webkit-user-select: none;
+  user-select: none;
+  margin-right: 0.4em;
+  padding: 0 0.4em 0 0.4em;
+  color: #737679
+}
+
+/* LineNumbers */
+html.dark .chroma .ln {
+  white-space: pre;
+  -webkit-user-select: none;
+  user-select: none;
+  margin-right: 0.4em;
+  padding: 0 0.4em 0 0.4em;
+  color: #6e7681
+}
+
+/* Line */
+html.dark .chroma .line {
+  display: flex;
+}
+
+/* Keyword */
+html.dark .chroma .k {
+  color: #ff7b72
+}
+
+/* KeywordConstant */
+html.dark .chroma .kc {
+  color: #79c0ff
+}
+
+/* KeywordDeclaration */
+html.dark .chroma .kd {
+  color: #ff7b72
+}
+
+/* KeywordNamespace */
+html.dark .chroma .kn {
+  color: #ff7b72
+}
+
+/* KeywordPseudo */
+html.dark .chroma .kp {
+  color: #79c0ff
+}
+
+/* KeywordReserved */
+html.dark .chroma .kr {
+  color: #ff7b72
+}
+
+/* KeywordType */
+html.dark .chroma .kt {
+  color: #ff7b72
+}
+
+/* Name */
+html.dark .chroma .n {}
+
+/* NameAttribute */
+html.dark .chroma .na {}
+
+/* NameBuiltin */
+html.dark .chroma .nb {}
+
+/* NameBuiltinPseudo */
+html.dark .chroma .bp {}
+
+/* NameClass */
+html.dark .chroma .nc {
+  color: #f0883e;
+  font-weight: bold
+}
+
+/* NameConstant */
+html.dark .chroma .no {
+  color: #79c0ff;
+  font-weight: bold
+}
+
+/* NameDecorator */
+html.dark .chroma .nd {
+  color: #d2a8ff;
+  font-weight: bold
+}
+
+/* NameEntity */
+html.dark .chroma .ni {
+  color: #ffa657
+}
+
+/* NameException */
+html.dark .chroma .ne {
+  color: #f0883e;
+  font-weight: bold
+}
+
+/* NameFunction */
+html.dark .chroma .nf {
+  color: #d2a8ff;
+  font-weight: bold
+}
+
+/* NameFunctionMagic */
+html.dark .chroma .fm {}
+
+/* NameLabel */
+html.dark .chroma .nl {
+  color: #79c0ff;
+  font-weight: bold
+}
+
+/* NameNamespace */
+html.dark .chroma .nn {
+  color: #ff7b72
+}
+
+/* NameOther */
+html.dark .chroma .nx {}
+
+/* NameProperty */
+html.dark .chroma .py {
+  color: #79c0ff
+}
+
+/* NameTag */
+html.dark .chroma .nt {
+  color: #7ee787
+}
+
+/* NameVariable */
+html.dark .chroma .nv {
+  color: #79c0ff
+}
+
+/* NameVariableClass */
+html.dark .chroma .vc {}
+
+/* NameVariableGlobal */
+html.dark .chroma .vg {}
+
+/* NameVariableInstance */
+html.dark .chroma .vi {}
+
+/* NameVariableMagic */
+html.dark .chroma .vm {}
+
+/* Literal */
+html.dark .chroma .l {
+  color: #a5d6ff
+}
+
+/* LiteralDate */
+html.dark .chroma .ld {
+  color: #79c0ff
+}
+
+/* LiteralString */
+html.dark .chroma .s {
+  color: #a5d6ff
+}
+
+/* LiteralStringAffix */
+html.dark .chroma .sa {
+  color: #79c0ff
+}
+
+/* LiteralStringBacktick */
+html.dark .chroma .sb {
+  color: #a5d6ff
+}
+
+/* LiteralStringChar */
+html.dark .chroma .sc {
+  color: #a5d6ff
+}
+
+/* LiteralStringDelimiter */
+html.dark .chroma .dl {
+  color: #79c0ff
+}
+
+/* LiteralStringDoc */
+html.dark .chroma .sd {
+  color: #a5d6ff
+}
+
+/* LiteralStringDouble */
+html.dark .chroma .s2 {
+  color: #a5d6ff
+}
+
+/* LiteralStringEscape */
+html.dark .chroma .se {
+  color: #79c0ff
+}
+
+/* LiteralStringHeredoc */
+html.dark .chroma .sh {
+  color: #79c0ff
+}
+
+/* LiteralStringInterpol */
+html.dark .chroma .si {
+  color: #a5d6ff
+}
+
+/* LiteralStringOther */
+html.dark .chroma .sx {
+  color: #a5d6ff
+}
+
+/* LiteralStringRegex */
+html.dark .chroma .sr {
+  color: #79c0ff
+}
+
+/* LiteralStringSingle */
+html.dark .chroma .s1 {
+  color: #a5d6ff
+}
+
+/* LiteralStringSymbol */
+html.dark .chroma .ss {
+  color: #a5d6ff
+}
+
+/* LiteralNumber */
+html.dark .chroma .m {
+  color: #a5d6ff
+}
+
+/* LiteralNumberBin */
+html.dark .chroma .mb {
+  color: #a5d6ff
+}
+
+/* LiteralNumberFloat */
+html.dark .chroma .mf {
+  color: #a5d6ff
+}
+
+/* LiteralNumberHex */
+html.dark .chroma .mh {
+  color: #a5d6ff
+}
+
+/* LiteralNumberInteger */
+html.dark .chroma .mi {
+  color: #a5d6ff
+}
+
+/* LiteralNumberIntegerLong */
+html.dark .chroma .il {
+  color: #a5d6ff
+}
+
+/* LiteralNumberOct */
+html.dark .chroma .mo {
+  color: #a5d6ff
+}
+
+/* Operator */
+html.dark .chroma .o {
+  color: #ff7b72;
+  font-weight: bold
+}
+
+/* OperatorWord */
+html.dark .chroma .ow {
+  color: #ff7b72;
+  font-weight: bold
+}
+
+/* Punctuation */
+html.dark .chroma .p {}
+
+/* Comment */
+html.dark .chroma .c {
+  color: #8b949e;
+  font-style: italic
+}
+
+/* CommentHashbang */
+html.dark .chroma .ch {
+  color: #8b949e;
+  font-style: italic
+}
+
+/* CommentMultiline */
+html.dark .chroma .cm {
+  color: #8b949e;
+  font-style: italic
+}
+
+/* CommentSingle */
+html.dark .chroma .c1 {
+  color: #8b949e;
+  font-style: italic
+}
+
+/* CommentSpecial */
+html.dark .chroma .cs {
+  color: #8b949e;
+  font-weight: bold;
+  font-style: italic
+}
+
+/* CommentPreproc */
+html.dark .chroma .cp {
+  color: #8b949e;
+  font-weight: bold;
+  font-style: italic
+}
+
+/* CommentPreprocFile */
+html.dark .chroma .cpf {
+  color: #8b949e;
+  font-weight: bold;
+  font-style: italic
+}
+
+/* Generic */
+html.dark .chroma .g {}
+
+/* GenericDeleted */
+html.dark .chroma .gd {
+  color: #ffa198;
+  background-color: #490202
+}
+
+/* GenericEmph */
+html.dark .chroma .ge {
+  font-style: italic
+}
+
+/* GenericError */
+html.dark .chroma .gr {
+  color: #ffa198
+}
+
+/* GenericHeading */
+html.dark .chroma .gh {
+  color: #79c0ff;
+  font-weight: bold
+}
+
+/* GenericInserted */
+html.dark .chroma .gi {
+  color: #56d364;
+  background-color: #0f5323
+}
+
+/* GenericOutput */
+html.dark .chroma .go {
+  color: #8b949e
+}
+
+/* GenericPrompt */
+html.dark .chroma .gp {
+  color: #8b949e
+}
+
+/* GenericStrong */
+html.dark .chroma .gs {
+  font-weight: bold
+}
+
+/* GenericSubheading */
+html.dark .chroma .gu {
+  color: #79c0ff
+}
+
+/* GenericTraceback */
+html.dark .chroma .gt {
+  color: #ff7b72
+}
+
+/* GenericUnderline */
+html.dark .chroma .gl {
+  text-decoration: underline
+}
+
+/* TextWhitespace */
+html.dark .chroma .w {
+  color: #6e7681
+}

--- a/docs/site/assets/css/custom.css
+++ b/docs/site/assets/css/custom.css
@@ -9,6 +9,10 @@
   font-size: 1.0em;
 }
 
+.hextra-code-block:not(.no-wrap) pre {
+  text-wrap: auto;
+}
+
 /* code in headings */
 .content :where(h1, h2, h3, h4):not(:where([class~="not-prose"], [class~="not-prose"] *)) code {
   font-size: 100%;

--- a/docs/site/hugo.yaml
+++ b/docs/site/hugo.yaml
@@ -5,7 +5,7 @@ disablePathToLower: true
 
 markup:
   highlight:
-    style: github-dark
+    noClasses: false
 
 module:
   imports:

--- a/docs/site/layouts/_default/_markup/render-codeblock.html
+++ b/docs/site/layouts/_default/_markup/render-codeblock.html
@@ -1,0 +1,12 @@
+{{- $class := .Attributes.class | default "" -}}
+{{- $filename := .Attributes.filename | default "" -}}
+{{- $base_url := .Attributes.base_url | default "" -}}
+{{- $lang := .Attributes.lang | default .Type -}}
+
+<div class="hextra-code-block hx-relative hx-mt-6 first:hx-mt-0 hx-group/code {{ $class }}">
+  {{- partial "components/codeblock" (dict "filename" $filename "lang" $lang "base_url" $base_url "content" .Inner "options" .Options) -}}
+
+  {{- if or (eq site.Params.highlight.copy.enable nil) (site.Params.highlight.copy.enable) -}}
+    {{- partialCached "components/codeblock-copy-button" (dict "filename" $filename) $filename -}}
+  {{- end -}}
+</div>

--- a/docs/site/layouts/shortcodes/expand-all.html
+++ b/docs/site/layouts/shortcodes/expand-all.html
@@ -1,0 +1,19 @@
+<script lang="JS">
+function expandAll() {
+    var inputs = document.getElementsByTagName('details');
+
+    for(var i = 0; i < inputs.length; i++) {
+        inputs[i].open = true;
+    }
+}
+
+function collapseAll() {
+    var inputs = document.getElementsByTagName('details');
+
+    for(var i = 0; i < inputs.length; i++) {
+        inputs[i].open = false;
+    }
+}
+</script>
+<a class="" onclick="expandAll()" style="cursor:pointer; text-decoration: none;" title="Expand all">➕</a>&nbsp;
+<a class="" onclick="collapseAll()" style="cursor:pointer; text-decoration: none;" title="Collapse all">➖</a>

--- a/docs/site/layouts/shortcodes/html.html
+++ b/docs/site/layouts/shortcodes/html.html
@@ -1,0 +1,2 @@
+<!-- raw html -->
+{{.Inner}}

--- a/docs/templates/function.md
+++ b/docs/templates/function.md
@@ -1,0 +1,13 @@
+Mojo function{{template "source_link" .}}
+
+# `{{.Name}}`
+
+{{`{{<expand-all>}}`}}
+
+{{if .Overloads -}}
+{{range .Overloads -}}
+{{template "overload" . -}}
+{{end -}}
+{{else -}}
+{{template "overload" . -}}
+{{- end}}

--- a/docs/templates/methods.md
+++ b/docs/templates/methods.md
@@ -1,0 +1,10 @@
+{{define "methods" -}}
+{{if .Functions}}## Methods
+
+{{`{{<expand-all>}}`}}
+
+{{range .Functions -}}
+{{template "method" . -}}
+{{end}}
+{{end}}
+{{- end}}

--- a/docs/templates/overload.md
+++ b/docs/templates/overload.md
@@ -1,0 +1,12 @@
+{{define "overload" -}}
+{{template "signature_func" .}}
+
+{{`{{<html>}}`}}<details>
+<summary>{{`{{</html>}}`}}{{if .Summary}}{{.Summary}}{{else}}Details{{end}}{{`{{<html>}}`}}</summary>{{`{{</html>}}`}}
+{{template "description" . -}}
+{{template "func_parameters" . -}}
+{{template "func_args" . -}}
+{{template "func_returns" . -}}
+{{template "func_raises" . -}}
+{{`{{<html>}}`}}</details>{{`{{</html>}}`}}
+{{end}}

--- a/modo.yaml
+++ b/modo.yaml
@@ -41,7 +41,7 @@ dry-run: false
 case-insensitive: false
 
 # Directories to scan for templates to overwrite builtin templates.
-templates: []
+templates: [docs/templates]
 
 # Bash scripts to run before build as well as test.
 pre-run:


### PR DESCRIPTION
Makes the following changes to the docs, each in a separate commit.
Feel free to select what you want, and I will change the PR accordingly.

## Code blocks change color according to light/dark theme

IMO a must-have :wink:

> Adds CSS and changes the syntax highlighting settings in `hugo.yaml`.

![grafik](https://github.com/user-attachments/assets/d51b7af0-2cca-4317-9402-2cd6f66e1a4d)
![grafik](https://github.com/user-attachments/assets/6f9c3c5c-c6d3-4ea9-a271-d0767f46e12d)

## Function and method details are collapsed for a better overview of overloads

Really improves overview, particularly when additionally reducing paragraph spacing and line height, as in larecs or modo docs (not done here).

> Adds two Hugo shortcodes and uses them in Modo template overwrites.

![grafik](https://github.com/user-attachments/assets/fc647631-cfb7-4949-b930-4df64665e910)

"Details" is there because there is no summary for these initializers:

![grafik](https://github.com/user-attachments/assets/2e8b769d-54e7-4baa-af7e-78f93c14a7c5)

## Word wrap in code blocks for signatures without scrolling

Probably a matter of taste.

> Adds a bit of CSS, and overwrites a Hugo template to allow for opt-out (see below).

![grafik](https://github.com/user-attachments/assets/e068c64b-4498-43f1-a434-6004e15e3071)

The last commit shows how to opt-out of word wrapping:

````md
```mojo {class="no-wrap"}
code that should not wrap
```
````

However, `mojo test` does not recognize blocks with attributes and wil not test them. (These attributes are not a Modo feature, they are kind of a standard and we just pass them through to Hugo, which adds the class to the blocks in HTML).

You can, however, still have your code examples tested by Modo:

````md
```mojo {doctest="my-test-name" class="no-wrap"}
code that should not wrap, but to be tested
```
````

See section [doc-tests](https://mlange-42.github.io/modo/guide/features/doctests/) in the user guide for details.
