### PR TITLE
chore: update to Mojo 1.0.0b2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 # magic environments
 .magic
 *.mojopkg
+*.mojoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Migrate to Mojo 1.0.0b2 and MAX 26.4.
+- Update move initializers, pointer origins, generic bounds, constraints, and documentation imports for 1.0.0b2.
+- Replace `mojo package`/`.mojopkg` with `mojo precompile`/`.mojoc` and run test entry points with `mojo run`.
+
 ## v0.22.0
 
 - Migrate to Mojo 1.0.0b1.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ version = "0.1.0"
 [tasks]
 
 [dependencies]
-mojo = "=1.0.0b1"
+mojo = "=1.0.0b2"
 ```
 
 then run:

--- a/extramojo/bstr/bstr.mojo
+++ b/extramojo/bstr/bstr.mojo
@@ -17,7 +17,7 @@ def find_chr_all_occurrences(haystack: Span[UInt8, _], chr: UInt8) -> List[Int]:
     """Find all the occurrences of `chr` in the input buffer.
 
     ```mojo
-    from testing import assert_equal
+    from std.testing import assert_equal
     from extramojo.bstr.bstr import find_chr_all_occurrences
 
     var haystack = "ATCGACCATCGAGATCATGTTTCAT"
@@ -65,7 +65,7 @@ def is_ascii_uppercase(value: UInt8) -> Bool:
     """Check if a byte is ASCII uppercase.
 
     ```mojo
-    from testing import assert_true, assert_false
+    from std.testing import assert_true, assert_false
     from extramojo.bstr.bstr import is_ascii_uppercase
 
     for ascii_letter in range(ord("A"), ord("Z")+1):
@@ -83,7 +83,7 @@ def is_ascii_lowercase(value: UInt8) -> Bool:
     """Check if a byte is ASCII lowercase.
 
     ```mojo
-    from testing import assert_true, assert_false
+    from std.testing import assert_true, assert_false
     from extramojo.bstr.bstr import is_ascii_lowercase
 
     for ascii_letter in range(ord("A"), ord("Z")+1):
@@ -101,7 +101,7 @@ def to_ascii_lowercase(mut buffer: List[UInt8]):
     """Lowercase all ascii a-zA-Z characters.
 
     ```mojo
-    from testing import assert_equal
+    from std.testing import assert_equal
     from extramojo.bstr.bstr import to_ascii_lowercase
     var test = List("ABCdefgHIjklmnOPQRSTUVWXYZABCdefgHIjklmnOPQRSTUVWXYZABCdefgHIjklmnOPQRSTUVWXYZABCdefgHIjklmnOPQRSTUVWXYZABCdefgHIjklmnOPQRSTUVWXYZ".as_bytes())
     var expected = List("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz".as_bytes())
@@ -155,7 +155,7 @@ def to_ascii_uppercase(mut buffer: List[UInt8]):
     """Uppercase all ascii a-zA-Z characters.
 
     ```mojo
-    from testing import assert_equal
+    from std.testing import assert_equal
     from extramojo.bstr.bstr import to_ascii_uppercase
     var test = List("ABCdefgHIjklmnOPQRSTUVWXYZABCdefgHIjklmnOPQRSTUVWXYZABCdefgHIjklmnOPQRSTUVWXYZABCdefgHIjklmnOPQRSTUVWXYZABCdefgHIjklmnOPQRSTUVWXYZ".as_bytes())
     var expected = List("ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ".as_bytes())
@@ -212,7 +212,7 @@ def find(haystack: Span[UInt8, _], needle: Span[UInt8, _]) -> Optional[Int]:
     if they match the rest of the needle.
 
     ```mojo
-    from testing import assert_equal
+    from std.testing import assert_equal
     from extramojo.bstr.bstr import find
 
     var haystack = "ABCDEFGhijklmnop".as_bytes()
@@ -275,7 +275,7 @@ struct SplitIterator[is_mutable: Bool, //, origin: Origin[mut=is_mutable]](
     TODO: these test run fine in the test module, but not in doctests.
 
     ```
-    from testing import assert_equal
+    from std.testing import assert_equal
     from extramojo.bstr.bstr import SplitIterator
     var input = "ABCD\tEFGH\tIJKL\nMNOP".as_bytes()
     var expected = List(
@@ -289,8 +289,7 @@ struct SplitIterator[is_mutable: Bool, //, origin: Origin[mut=is_mutable]](
     ```
 
     ```
-    from collections.string.string_slice import StringSlice
-    from testing import assert_equal
+    from std.testing import assert_equal
     from extramojo.bstr.bstr import SplitIterator
 
     var input = "ABCD\tEFGH\tIJKL\nMNOP".as_bytes()

--- a/extramojo/bstr/memchr.mojo
+++ b/extramojo/bstr/memchr.mojo
@@ -20,7 +20,7 @@ def memchr[
     Function to find the next occurrence of character.
 
     ```mojo
-    from testing import assert_equal
+    from std.testing import assert_equal
     from extramojo.bstr.memchr import memchr
 
     assert_equal(memchr("enlivened,unleavened,Arnulfo's,Unilever's,unloved|Anouilh,analogue,analogy".as_bytes(), ord("|")), 49)
@@ -100,7 +100,7 @@ def memchr_wide(haystack: Span[UInt8, _], chr: UInt8, start: Int = 0) -> Int:
     This function does more unrolling and will be faster if the search if over longer distances. If in doubt use `memchr`.
 
     ```mojo
-    from testing import assert_equal
+    from std.testing import assert_equal
     from extramojo.bstr.memchr import memchr_wide
 
     assert_equal(memchr_wide("enlivened,unleavened,Arnulfo's,Unilever's,unloved|Anouilh,analogue,analogy".as_bytes(), ord("|")), 49)

--- a/extramojo/cli/parser.mojo
+++ b/extramojo/cli/parser.mojo
@@ -1,7 +1,7 @@
 """A very basic CLI Opt Parser.
 
 ```mojo {doctest="parser" class="no-wrap"}
-from testing import assert_equal, assert_true
+from std.testing import assert_equal, assert_true
 from extramojo.cli.parser import OptParser, OptConfig, OptKind
 
 var args = List(String("--file"), String("/path/to/thing"), String("--count"), String("42"), String("--fraction"), String("-0.2"), String("--verbose"), String("ExtraFile.tsv"))
@@ -546,7 +546,7 @@ struct SubcommandParser(Copyable, Movable):
     The parser is for the options for the subcommand.
 
     ```mojo
-    from testing import assert_equal, assert_true
+    from std.testing import assert_equal, assert_true
     from extramojo.cli.parser import OptParser, OptConfig, OptKind, SubcommandParser, Subcommand
 
     var args = List(String("do-work"), String("--file"), String("/path/to/thing"), String("--count"), String("42"), String("--fraction"), String("-0.2"), String("--verbose"))

--- a/extramojo/collections/bbhash/bbhash.mojo
+++ b/extramojo/collections/bbhash/bbhash.mojo
@@ -3,7 +3,7 @@
 ## Examples
 
 ```mojo
-from testing import assert_true, assert_false
+from std.testing import assert_true, assert_false
 from extramojo.collections.bbhash.bbhash import BBHash
 
 var keys: List[String] = ["fox", "cat", "dog", "mouse", "frog"]
@@ -17,8 +17,8 @@ Verify that a returned True value for key matches the key from the original
 input set:
 
 ```mojo
-from hashlib.hash import hash
-from testing import assert_true, assert_false
+from std.hashlib.hash import hash
+from std.testing import assert_true, assert_false
 from extramojo.collections.bbhash.bbhash import BBHash
 
 var keys: List[String] = ["fox", "cat", "dog", "mouse", "frog"]

--- a/extramojo/collections/bitvec.mojo
+++ b/extramojo/collections/bitvec.mojo
@@ -91,7 +91,7 @@ struct BitVec(Boolable, Copyable, Movable, Sized, Writable):
     comptime WORD_BYTEWIDTH = bit_width_of[Self.WORD.dtype]() // 8
     comptime WORD = Scalar[Self.WORD_DTYPE]
     comptime WORD_PTR = UnsafePointer[
-        mut=True, type=Self.WORD, origin=ExternalOrigin[mut=True]
+        mut=True, type=Self.WORD, origin=UntrackedOrigin[mut=True]
     ]
 
     var data: Self.WORD_PTR
@@ -178,10 +178,10 @@ struct BitVec(Boolable, Copyable, Movable, Sized, Writable):
         return copy^
 
     @always_inline
-    def __init__(out self, *, deinit take: Self):
-        self.data = take.data
-        self._len = take._len
-        self._capacity = take._capacity
+    def __init__(out self, *, deinit move: Self):
+        self.data = move.data
+        self._len = move._len
+        self._capacity = move._capacity
 
     @always_inline
     def __del__(deinit self):

--- a/extramojo/io/buffered.mojo
+++ b/extramojo/io/buffered.mojo
@@ -6,7 +6,7 @@ Buffered reading and writing.
 BufferedReader:
 
 ```mojo
-from testing import assert_equal
+from std.testing import assert_equal
 from extramojo.io.buffered import BufferedReader
 
 def test_read_until(file: String, expected_lines: List[String]) raises:
@@ -193,7 +193,7 @@ struct BufferedReader(Movable):
     var fh: FileHandle
     """The internal filehandle to read from."""
     var buffer: UnsafePointer[
-        mut=True, type=UInt8, origin=ExternalOrigin[mut=True]
+        mut=True, type=UInt8, origin=UntrackedOrigin[mut=True]
     ]
     """The internal buffer."""
     var file_offset: Int
@@ -232,13 +232,13 @@ struct BufferedReader(Movable):
     def __enter__(var self) -> Self:
         return self^
 
-    def __init__(out self, *, deinit take: Self):
-        self.fh = take.fh^
-        self.file_offset = take.file_offset
-        self.buffer_offset = take.buffer_offset
-        self.buffer = take.buffer
-        self.buffer_capacity = take.buffer_capacity
-        self.buffer_len = take.buffer_len
+    def __init__(out self, *, deinit move: Self):
+        self.fh = move.fh^
+        self.file_offset = move.file_offset
+        self.buffer_offset = move.buffer_offset
+        self.buffer = move.buffer
+        self.buffer_capacity = move.buffer_capacity
+        self.buffer_len = move.buffer_len
 
     def read_bytes(mut self, mut buffer: List[UInt8]) raises -> Int:
         """Read up to `len(buffer)` bytes.
@@ -347,7 +347,9 @@ struct BufferedReader(Movable):
         return self.buffer_len
 
 
-struct BufferedWriter[W: Movable & Writer](Movable, Writer):
+struct BufferedWriter[W: Movable & Writer & ImplicitlyDestructible](
+    Movable, Writer
+):
     """A BufferedWriter.
 
     ## Example
@@ -393,11 +395,11 @@ struct BufferedWriter[W: Movable & Writer](Movable, Writer):
     def __enter__(var self) -> Self:
         return self^
 
-    def __init__(out self, *, deinit take: Self):
-        self.inner = take.inner^
-        self.buffer = take.buffer^
-        self.buffer_capacity = take.buffer_capacity
-        self.buffer_len = take.buffer_len
+    def __init__(out self, *, deinit move: Self):
+        self.inner = move.inner^
+        self.buffer = move.buffer^
+        self.buffer_capacity = move.buffer_capacity
+        self.buffer_len = move.buffer_len
 
     def close(mut self) raises:
         self.flush()

--- a/extramojo/io/delimited.mojo
+++ b/extramojo/io/delimited.mojo
@@ -7,8 +7,7 @@ Compile-time known fields:
 TODO: this should be two different examples, but the doc parser can't seem to handle that for this example.
 
 ```mojo
-from collections.string import StringSlice
-from testing import assert_equal
+from std.testing import assert_equal
 
 from extramojo.bstr.bstr import SplitIterator
 from extramojo.cli.parser import ParsedOpts
@@ -261,14 +260,14 @@ struct DelimReader[RowType: FromDelimited](Movable):
             self._skip_header()
         self._get_next()
 
-    def __init__(out self, *, deinit take: Self):
-        self.delim = take.delim
-        self.reader = take.reader^
-        self.next_elem = take.next_elem^
-        self.buffer = take.buffer^
-        self.len = take.len
-        self.has_header = take.has_header
-        self.header_values = take.header_values^
+    def __init__(out self, *, deinit move: Self):
+        self.delim = move.delim
+        self.reader = move.reader^
+        self.next_elem = move.next_elem^
+        self.buffer = move.buffer^
+        self.len = move.len
+        self.has_header = move.has_header
+        self.header_values = move.header_values^
 
     def __len__(read self) -> Int:
         return self.len
@@ -331,7 +330,7 @@ trait ToDelimited:
         ...
 
 
-struct DelimWriter[W: Movable & Writer](Movable):
+struct DelimWriter[W: Movable & Writer & ImplicitlyDestructible](Movable):
     """Write delimited data."""
 
     var delim: String
@@ -362,11 +361,11 @@ struct DelimWriter[W: Movable & Writer](Movable):
         self.write_header = write_header
         self.needs_to_write_header = write_header
 
-    def __init__(out self, *, deinit take: Self):
-        self.delim = take.delim^
-        self.writer = take.writer^
-        self.write_header = take.write_header
-        self.needs_to_write_header = take.needs_to_write_header
+    def __init__(out self, *, deinit move: Self):
+        self.delim = move.delim^
+        self.writer = move.writer^
+        self.write_header = move.write_header
+        self.needs_to_write_header = move.needs_to_write_header
 
     def __enter__(var self) -> Self:
         return self^

--- a/extramojo/math/ops.mojo
+++ b/extramojo/math/ops.mojo
@@ -3,8 +3,10 @@ from std.sys import llvm_intrinsic
 
 @always_inline
 def saturating_sub[
-    data: DType where data.is_integral(), width: Int
-](lhs: SIMD[data, width], rhs: SIMD[data, width]) -> SIMD[data, width]:
+    data: DType, width: Int
+](lhs: SIMD[data, width], rhs: SIMD[data, width]) -> SIMD[
+    data, width
+] where data.is_integral():
     """Saturating SIMD subtraction.
 
     https://llvm.org/docs/LangRef.html#llvm-usub-sat-intrinsics
@@ -19,8 +21,10 @@ def saturating_sub[
 
 @always_inline
 def saturating_add[
-    data: DType where data.is_integral(), width: Int
-](lhs: SIMD[data, width], rhs: SIMD[data, width]) -> SIMD[data, width]:
+    data: DType, width: Int
+](lhs: SIMD[data, width], rhs: SIMD[data, width]) -> SIMD[
+    data, width
+] where data.is_integral():
     """Saturating SIMD addition.
 
     https://llvm.org/docs/LangRef.html#llvm-uadd-sat-intrinsics

--- a/extramojo/stats/sampling.mojo
+++ b/extramojo/stats/sampling.mojo
@@ -16,8 +16,8 @@ struct ReservoirSampler[T: Copyable & ImplicitlyDestructible](
     Sample all the elements, this should retain the order since we always automatically take the first N elements.
 
     ```mojo
-    from random import seed
-    from testing import assert_equal
+    from std.random import seed
+    from std.testing import assert_equal
 
     from extramojo.stats.sampling import ReservoirSampler
 

--- a/modo.yaml
+++ b/modo.yaml
@@ -61,8 +61,8 @@ pre-test: []
 # Also runs after build if 'tests' is given.
 post-test:
   - |
-    echo Running 'mojo test'...
-    pixi run mojo test -I . docs/test
+    echo Running generated Mojo tests...
+    find docs/test -name '*.mojo' -exec pixi run mojo run -I . {} \;
     echo Done.
 
 # Bash scripts to run after build.

--- a/pixi.lock
+++ b/pixi.lock
@@ -32,10 +32,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
-      - conda: https://conda.modular.com/max/linux-64/mojo-1.0.0b1-release.conda
-      - conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0b1-release.conda
-      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b1-release.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.4.0-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-1.0.0b2-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0b2-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b2-release.conda
       - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
@@ -82,10 +82,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libuuid-2.42-h1022ec0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
-      - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
-      - conda: https://conda.modular.com/max/linux-aarch64/mojo-1.0.0b1-release.conda
-      - conda: https://conda.modular.com/max/linux-aarch64/mojo-compiler-1.0.0b1-release.conda
-      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b1-release.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.4.0-release.conda
+      - conda: https://conda.modular.com/max/linux-aarch64/mojo-1.0.0b2-release.conda
+      - conda: https://conda.modular.com/max/linux-aarch64/mojo-compiler-1.0.0b2-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b2-release.conda
       - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.2-h546c87b_0.conda
@@ -126,10 +126,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libsodium-1.0.21-h1a92334_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
-      - conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0b1-release.conda
-      - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0b1-release.conda
-      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b1-release.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.4.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0b2-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0b2-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b2-release.conda
       - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
@@ -699,10 +699,10 @@ packages:
   license_family: Other
   size: 47759
   timestamp: 1774072956767
-- conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
+- conda: https://conda.modular.com/max/noarch/mblack-26.4.0-release.conda
   noarch: python
-  sha256: c7c36d5b223862acffaaacdfc6f672ca198a046a66f4a956ca57933123fb93b2
-  md5: 63c657fb1780079c3f6cbb7a758a16d2
+  sha256: e2497cbefbf5d962cd0db8c1b893e7e48d8f3603cab84a9d8bad0030b5bb26b1
+  md5: ec6bf2b9588f5ba4bd3472c0773c4892
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -712,74 +712,74 @@ packages:
   - platformdirs >=2
   - tomli >=1.1.0
   license: LicenseRef-Modular-Proprietary
-  size: 135000
-  timestamp: 1777574970629
-- conda: https://conda.modular.com/max/linux-64/mojo-1.0.0b1-release.conda
-  sha256: a8f36a83ece187307d7d78c152828eac58edb002d515de2bcbe9f5a19388b70c
-  md5: 11bdf0256d179b89dc00ca4150c6963c
+  size: 135301
+  timestamp: 1781220755102
+- conda: https://conda.modular.com/max/linux-64/mojo-1.0.0b2-release.conda
+  sha256: 7553366c138bae2fcf8617582f1bb6d6b6742087bd6a83ea83aa41c023499382
+  md5: 8d4390edde2dcf29880c57b3088f15aa
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b1
-  - mblack ==26.3.0
+  - mojo-compiler ==1.0.0b2
+  - mblack ==26.4.0
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 94106548
-  timestamp: 1777595784229
-- conda: https://conda.modular.com/max/linux-aarch64/mojo-1.0.0b1-release.conda
-  sha256: bcc1b91f2d39ab25e430d2de0c552b6f5afe03c13d8d726c4b2aca4ce5e0901e
-  md5: c6970314e455e0c04eee0be160adbebb
+  size: 96475709
+  timestamp: 1781237127405
+- conda: https://conda.modular.com/max/linux-aarch64/mojo-1.0.0b2-release.conda
+  sha256: e47bc03b9cbe2cf65f2f1c2bb86f3e6b0039265f7b1857af56a24bf155c6556e
+  md5: 31ac48fd8bd56c6e2ffc5c1391b55735
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b1
-  - mblack ==26.3.0
+  - mojo-compiler ==1.0.0b2
+  - mblack ==26.4.0
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 92647635
-  timestamp: 1777595798392
-- conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0b1-release.conda
-  sha256: 2980b825e3eedb153f68f74edeaae6a7b819912c3eb6e49f1eed7d25f883e050
-  md5: b5f2c6b04a9e2bbe199fef1ea5677014
+  size: 94460605
+  timestamp: 1781237159286
+- conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0b2-release.conda
+  sha256: 39bb59a309af5e4c78c077263e5824e33bba8159a1e0fc39ff2786a1f9d5762b
+  md5: 1a6b6dd12763032e46b956407b39ab48
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b1
-  - mblack ==26.3.0
+  - mojo-compiler ==1.0.0b2
+  - mblack ==26.4.0
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 83375027
-  timestamp: 1777596028766
-- conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0b1-release.conda
-  sha256: 706c7f8e2be740dda8039bf96182b578bfbbd9220ca1a7f762e1f82acc4eb784
-  md5: 2fc6038c3837e50bb855bcf7f930c1c9
+  size: 84573003
+  timestamp: 1781237324882
+- conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0b2-release.conda
+  sha256: 87f8e9ef573f37072423aeb56a7c468bdb5f5889476bce4aa7c3396665c651fe
+  md5: 6be85d17872f5c2370015ca4ec07dd0d
   depends:
-  - mojo-python ==1.0.0b1
+  - mojo-python ==1.0.0b2
   license: LicenseRef-Modular-Proprietary
-  size: 89421276
-  timestamp: 1777595833113
-- conda: https://conda.modular.com/max/linux-aarch64/mojo-compiler-1.0.0b1-release.conda
-  sha256: 6d6973cc34960597e786ad0f0ed0eba2c005d08eeefd37df53d2cd489ee2acd6
-  md5: 6b81a95a59f729be52dc9685210165e5
+  size: 85342385
+  timestamp: 1781237127405
+- conda: https://conda.modular.com/max/linux-aarch64/mojo-compiler-1.0.0b2-release.conda
+  sha256: 3dcafb1b921930d7a6352ce81fe09470e922d7bf77fcfb76ab545fd8bbcbf86a
+  md5: 5afaacc7f8cd470a3cb152e096e7c78a
   depends:
-  - mojo-python ==1.0.0b1
+  - mojo-python ==1.0.0b2
   license: LicenseRef-Modular-Proprietary
-  size: 86382462
-  timestamp: 1777595795606
-- conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0b1-release.conda
-  sha256: 3e0d6e6e814cb39d14d24234eb8f2ac6524379ea0a9c398a54e77598844e96d6
-  md5: fe08c02512b02563a0b878eeb32a684b
+  size: 82054363
+  timestamp: 1781237158841
+- conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0b2-release.conda
+  sha256: 91c4d590a152ec2e26846955fcd7ec02796dfaffefa006a1c0c5790575be2051
+  md5: cd8d3f4a22e5f14dd909d0d5570c4940
   depends:
-  - mojo-python ==1.0.0b1
+  - mojo-python ==1.0.0b2
   license: LicenseRef-Modular-Proprietary
-  size: 67503416
-  timestamp: 1777596016502
-- conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b1-release.conda
+  size: 62655166
+  timestamp: 1781237320083
+- conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b2-release.conda
   noarch: python
-  sha256: b0554c7705685c86e8a8063bcd11ed58897a498c8e1e19ef045f5ebba2c8874f
-  md5: d0ad2f8ba3758f03bfda84d92bb34b67
+  sha256: 37bf44a74edcd2ebaec7fe8299ef183e006ad051bfcf21caa06becc0e0eeffd5
+  md5: 8781bd673909835fa59ce818e3835839
   depends:
   - python >=3.10
   license: LicenseRef-Modular-Proprietary
-  size: 23114
-  timestamp: 1777594699418
+  size: 24682
+  timestamp: 1781220753246
 - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,28 +20,26 @@ backend = { name = "pixi-build-mojo", version = "0.*", channels = [
 ] }
 
 [package.host-dependencies]
-mojo-compiler = "=1.0.0b1"
+mojo-compiler = "=1.0.0b2"
 
 [package.build-dependencies]
-mojo-compiler = "=1.0.0b1"
+mojo-compiler = "=1.0.0b2"
 
 [package.run-dependencies]
-mojo-compiler = "=1.0.0b1"
+mojo-compiler = "=1.0.0b2"
 
 # These are basically just dev deps, the real deps are specified in the recipe.yaml
 [dependencies]
-mojo = "=1.0.0b1"
+mojo = "=1.0.0b2"
 
 [tasks]
-build = "pixi run mojo package extramojo -o extramojo.mojopkg"
+build = "pixi run mojo precompile extramojo -o extramojo.mojoc"
 r = { cmd = "pixi run mojo run -I . " }                                                                    # run
 t = { cmd = "sh -c 'find ./tests -name test_*.mojo | xargs -I % pixi run mojo run -debug-level=line-tables -I . -D ASSERT=all %'" } # test
-# Mojo 1.0.0b1 may enable AVX-512 on some GitHub x86_64 runners that do not expose AVX-512 CPU flags,
+# Mojo may enable AVX-512 on some GitHub x86_64 runners that do not expose AVX-512 CPU flags,
 # causing ASAN test binaries to trap with illegal instructions in stdlib code.
 t-asan = { cmd = "sh -c 'target_features=\"\"; if [ \"$(uname -m)\" = \"x86_64\" ]; then target_features=\"--target-features -avx512bf16,-avx512bitalg,-avx512bw,-avx512cd,-avx512dq,-avx512f,-avx512ifma,-avx512vbmi,-avx512vbmi2,-avx512vl,-avx512vnni,-avx512vpopcntdq\"; fi; find ./tests -name test_*.mojo | xargs -I % sh -c \"pixi run mojo build $target_features --sanitize address -debug-level=line-tables -I . -D ASSERT=all % -o /tmp/test_bin && /tmp/test_bin\"'" } # test with ASAN
 format = "pixi run mojo format ./"
-#t = { cmd = "pixi run mojo test -I . -D ASSERT=all" }
-#test = { cmd = "pixi run mojo run -I . tests/test_file.mojo", depends-on = ["t",] }
 
 # rattler-build tasks
 rbuild = "pixi build"

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   version: "0.20.1"
-  max_version: "=26.3.0"
+  max_version: "=26.4.0"
 
 package:
   name: "extramojo"
@@ -15,7 +15,7 @@ source:
 build:
   number: 0
   script:
-    - mojo package extramojo -o ${{ PREFIX }}/lib/mojo/extramojo.mojopkg
+    - mojo precompile extramojo -o ${{ PREFIX }}/lib/mojo/extramojo.mojoc
 requirements:
   host:
     - max ${{ max_version }}
@@ -27,12 +27,12 @@ tests:
   - script:
       - if: unix
         then:
-          - mojo run -I ${{ PREFIX }}/lib/mojo/extramojo.mojopkg tests/test_file.mojo
-          - mojo test -I ${{ PREFIX }}/lib/mojo/extramojo.mojopkg tests/test_bstr.mojo
-          - mojo test -I ${{ PREFIX }}/lib/mojo/extramojo.mojopkg tests/math/test_ops.mojo
-          - mojo test -I ${{ PREFIX }}/lib/mojo/extramojo.mojopkg tests/collections/test_bitvec.mojo
-          - mojo test -I ${{ PREFIX }}/lib/mojo/extramojo.mojopkg tests/collections/bbhash/test_hash.mojo
-          - mojo test -I ${{ PREFIX }}/lib/mojo/extramojo.mojopkg tests/collections/bbhash/test_bbhash.mojo
+          - mojo run -I ${{ PREFIX }}/lib/mojo/extramojo.mojoc tests/test_file.mojo
+          - mojo run -I ${{ PREFIX }}/lib/mojo/extramojo.mojoc tests/test_bstr.mojo
+          - mojo run -I ${{ PREFIX }}/lib/mojo/extramojo.mojoc tests/math/test_ops.mojo
+          - mojo run -I ${{ PREFIX }}/lib/mojo/extramojo.mojoc tests/collections/test_bitvec.mojo
+          - mojo run -I ${{ PREFIX }}/lib/mojo/extramojo.mojoc tests/collections/bbhash/test_hash.mojo
+          - mojo run -I ${{ PREFIX }}/lib/mojo/extramojo.mojoc tests/collections/bbhash/test_bbhash.mojo
     requirements:
       run:
         - max ${{ max_version }}

--- a/tests/math/test_ops.mojo
+++ b/tests/math/test_ops.mojo
@@ -3,7 +3,7 @@ from std.testing import assert_equal, TestSuite
 from extramojo.math.ops import saturating_add, saturating_sub
 
 
-def _sat_add[dtype: DType where dtype.is_integral(), width: Int]() raises:
+def _sat_add[dtype: DType, width: Int]() raises where dtype.is_integral():
     comptime MIN = Scalar[dtype].MIN
     comptime MAX = Scalar[dtype].MAX
 
@@ -35,7 +35,7 @@ def test_saturating_add() raises:
                 _sat_add[dtype, width]()
 
 
-def _sat_sub[dtype: DType where dtype.is_integral(), width: Int]() raises:
+def _sat_sub[dtype: DType, width: Int]() raises where dtype.is_integral():
     comptime MIN = Scalar[dtype].MIN
     comptime MAX = Scalar[dtype].MAX
 


### PR DESCRIPTION
## Summary

- update Mojo and compiler pins from `1.0.0b1` to `1.0.0b2` and MAX metadata to 26.4
- migrate move initializers, pointer origins, generic bounds, trailing constraints, and documentation imports for 1.0.0b2
- replace `mojo package`/`.mojopkg` project commands with `mojo precompile`/`.mojoc`
- replace removed `mojo test` invocations with test entry points run through `mojo run`
- regenerate the Pixi lockfile and update README/CHANGELOG

Mojo 1.0.0b2 changelog: https://mojolang.org/releases/v1.0.0b2/

## Validation

- `pixi run build`
- `pixi run t`
- `pixi build`
- `mojo format` on all tracked Mojo files

`pixi run t-asan` could not link locally on macOS ARM64 because the ASAN runtime symbol `___asan_version_mismatch_check_v8` was unavailable. The ASAN CI job runs on Linux.
